### PR TITLE
Fix grammarly bug breaking site's height

### DIFF
--- a/templates/SimpleTemplate.js
+++ b/templates/SimpleTemplate.js
@@ -77,6 +77,7 @@ class SimpleTemplate extends Template {
                         Description
                     </label>
                     <textarea
+                        data-gramm={false}
                         className="h-32 appearance-none block w-full bg-grey-lighter text-grey-darker border border-grey-lighter rounded py-3 px-4"
                         id="grid-description" type="text"
                         onChange={this.handleChange}


### PR DESCRIPTION
## Description
Fixes Grammarly breaking the site's height by disabling Grammarly for the Description `textarea`.

## Related Issues
Fixes #8 